### PR TITLE
docs/readme: add note about openssl on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Compile and call the build.
 $ cargo build
 $ target/debug/leaf-examples --help
 ```
+*Note for OSX El Capitan users: `openssl` no longer ships with OSX by default. `brew link --force openssl` should fix the problem. If not, [see this Github issue](https://github.com/sfackler/rust-openssl/issues/255) for more details.*
 
 ## Datasets
 


### PR DESCRIPTION
I was alarmed when `cargo build` immediately failed. Adding this note could save developers a few minutes of panic and Googling.
