### PR TITLE
fix/nn-config: fix NN input vector dimensions [SKIP_CHANGELOG]

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,7 @@ fn run_mnist(model_name: Option<String>, batch_size: Option<usize>, learning_rat
     let mut confusion = ::leaf::solver::ConfusionMatrix::new(10);
     confusion.set_capacity(Some(1000));
 
-    let mut inp = SharedTensor::<f32>::new(backend.device(), &vec![batch_size, 1, 28, 28]).unwrap();
+    let mut inp = SharedTensor::<f32>::new(backend.device(), &vec![batch_size, 28, 28]).unwrap();
     let label = SharedTensor::<f32>::new(native_backend.device(), &vec![batch_size, 1]).unwrap();
     inp.add_device(native_backend.device()).unwrap();
 


### PR DESCRIPTION
It looks like input to NN should have `[batch_size, width, height]` dimensions instead of `[batch_size, 1, width, height]`, but I'm not completely sure. In case of `conv` and `mlp` input is reshaped explicitly with `Reshape` layer, in case of `linear` it's most likely reshaped implicitly to `[batch_size, width*height]`. Still it's not very clear what that `1` is for, looks like leftover from `conv`...
