### PR TITLE
fix/cargo: Add pkg-config to discover libraries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Michael Hirn <mj@autumnai.com>",
            "Maximilian Goisser <max@autumnai.com>"]
 
 [dependencies]
+pkg-config = "0.3.8"
 # cuticula = "0.1.4"
 leaf = { version = "0.2.0", default-features = false }
 collenchyma = { version = "0.0.8", default-features = false }


### PR DESCRIPTION
Had all sorts of problems linking in libraries until I found [this post](https://users.rust-lang.org/t/linking-to-cuda-library-in-leaf/4957) and added `pkg-config` to auto-discover the libraries.
